### PR TITLE
[ fix ] svg 네이밍 오류 수정

### DIFF
--- a/src/assets/svg/index.ts
+++ b/src/assets/svg/index.ts
@@ -1,9 +1,6 @@
-
 import PolygonIcon from '@/assets/svg/ic_ arrow_drop_down.svg?react';
-import ArrowrightIcon from '@/assets/svg/ic_arrow_right_white.svg?react';
-
 import ArrowRightIcon from '@/assets/svg/ic_arrow_right_black.svg?react';
-
+import ArrowrightIcon from '@/assets/svg/ic_arrow_right_white.svg?react';
 import CalendarGreyIcon from '@/assets/svg/ic_calendar_grey.svg?react';
 import CarWhiteIcon from '@/assets/svg/ic_car_white.svg?react';
 import RadioFilledIcon from '@/assets/svg/ic_check_round_fill.svg?react';
@@ -14,14 +11,11 @@ import CloseIcon from '@/assets/svg/ic_close.svg?react';
 import ExclamationIcon from '@/assets/svg/ic_exclamation_circle_navy.svg?react';
 import FlagKoreaIcon from '@/assets/svg/ic_flag_korea.svg?react';
 import FlightWhiteIcon from '@/assets/svg/ic_flight_white.svg?react';
-
 import FlightIcon from '@/assets/svg/ic_flight_white.svg?react';
-import HeartBlackIcon from '@/assets/svg/ic_heart_black.svg?react';
-import HeartIcon from '@/assets/svg/ic_heat_outline.svg?react';
-
 import HeartIcon from '@/assets/svg/ic_heart.svg?react';
+import HeartBlackIcon from '@/assets/svg/ic_heart_black.svg?react';
+import HeartOutlineIcon from '@/assets/svg/ic_heat_outline.svg?react';
 import ReviewStarIcon from '@/assets/svg/ic_hotel_star.svg?react';
-
 import HotelWhiteIcon from '@/assets/svg/ic_hotel_white.svg?react';
 import LikePageIcon from '@/assets/svg/ic_likepage.svg?react';
 import MainLogoIcon from '@/assets/svg/ic_mainolgo_white.svg?react';
@@ -36,14 +30,11 @@ import ProfileIcon from '@/assets/svg/ic_profile.svg?react';
 import ReviewIcon from '@/assets/svg/ic_review.svg?react';
 import ReviewFillFIcon from '@/assets/svg/ic_review_fill.svg?react';
 import SkyscannerLogoIcon from '@/assets/svg/ic_skyscanner_logo.svg?react';
-
+import StarIcon from '@/assets/svg/ic_star.svg?react';
 import EastarIcon from '@/assets/svg/img_eastar.svg?react';
 import JejuAirIcon from '@/assets/svg/img_jejuair.svg?react';
 import JinAirIcon from '@/assets/svg/img_jinair.svg?react';
 import KalIcon from '@/assets/svg/img_koreaair.svg?react';
-
-import StarIcon from '@/assets/svg/ic_star.svg?react';
-
 
 export {
 	CalendarGreyIcon,
@@ -66,18 +57,16 @@ export {
 	PlusFilledIcon,
 	ProfileIcon,
 	SkyscannerLogoIcon,
-
 	PolygonIcon,
 	ArrowrightIcon,
 	ExclamationIcon,
 	FlightIcon,
 	HeartBlackIcon,
-	HeartIcon,
+	HeartOutlineIcon,
 	EastarIcon,
 	JejuAirIcon,
 	JinAirIcon,
 	KalIcon,
-
 	ArrowRightIcon,
 	ReviewFillFIcon,
 	ReviewIcon,
@@ -85,5 +74,4 @@ export {
 	HeartIcon,
 	OwlIcon,
 	ReviewStarIcon,
-
 };

--- a/src/assets/svg/index.ts
+++ b/src/assets/svg/index.ts
@@ -14,7 +14,6 @@ import FlightWhiteIcon from '@/assets/svg/ic_flight_white.svg?react';
 import FlightIcon from '@/assets/svg/ic_flight_white.svg?react';
 import HeartIcon from '@/assets/svg/ic_heart.svg?react';
 import HeartBlackIcon from '@/assets/svg/ic_heart_black.svg?react';
-import HeartOutlineIcon from '@/assets/svg/ic_heat_outline.svg?react';
 import ReviewStarIcon from '@/assets/svg/ic_hotel_star.svg?react';
 import HotelWhiteIcon from '@/assets/svg/ic_hotel_white.svg?react';
 import LikePageIcon from '@/assets/svg/ic_likepage.svg?react';
@@ -62,7 +61,6 @@ export {
 	ExclamationIcon,
 	FlightIcon,
 	HeartBlackIcon,
-	HeartOutlineIcon,
 	EastarIcon,
 	JejuAirIcon,
 	JinAirIcon,


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #42

## ✅ 작업 리스트

- [x] svg 중복 이름 수정

## 🔧 작업 내용

![image](https://github.com/user-attachments/assets/cccb585f-4acc-48ac-b779-13f9a87dabb2)

![image](https://github.com/user-attachments/assets/06ae9136-c43c-474a-88fd-5ef030f14de9)

두 컴포넌트 내에 존재하는 하트 svg 아이콘의 중복 이름 선언이 있었습니다. 현재 해당 heart를 사용하는 페이지는 reservation 페이지내 항공권 컴포넌트와 호텔, 렌터카 카드 섹션 내에서만 사용되고 있기 때문에 타 페이지에 가는 영향은 없을 것이라 판단됩니다! 동일 기능을 수행하는 아이콘을 하나로 통합했습니다.

## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link
