### PR TITLE
[ Feat ] Home <-> Reservation 간 날짜 연동

### DIFF
--- a/src/components/home/Search.tsx
+++ b/src/components/home/Search.tsx
@@ -54,8 +54,12 @@ const Search = ({ onModalToggle, onChangeAbleCity }: props) => {
 
 	const navigate = useNavigate(); // useNavigate 훅 호출
 
+	const searchParams = new URLSearchParams(window.location.search);
+	const startDate = searchParams.get('startDate');
+	const finishDate = searchParams.get('finishDate');
+
 	const handleSearchClick = () => {
-		navigate('/reservation');
+		navigate(`/reservation?startDate=${startDate}&finishDate=${finishDate}`);
 	};
 
 	useEffect(() => {

--- a/src/components/reservation/DateFilter.tsx
+++ b/src/components/reservation/DateFilter.tsx
@@ -2,14 +2,16 @@ import { formatDate } from '@/utils/dateUtils';
 import styled from 'styled-components';
 
 interface DateFilterProps {
-	startDate: string;
-	finishDate: string;
+	startDate: string | null;
+	finishDate: string | null;
 }
 
 const DateFilter = ({ startDate, finishDate }: DateFilterProps) => {
-	const { month: startMonth, day: startDay, weekday: startWeekday } = formatDate(startDate);
-	const { month: finishMonth, day: finishDay, weekday: finishWeekday } = formatDate(finishDate);
+	const startFormatted = startDate ? formatDate(startDate) : { month: '', day: '', weekday: '' };
+	const finishFormatted = finishDate ? formatDate(finishDate) : { month: '', day: '', weekday: '' };
 
+	const { month: startMonth, day: startDay, weekday: startWeekday } = startFormatted;
+	const { month: finishMonth, day: finishDay, weekday: finishWeekday } = finishFormatted;
 	return (
 		<DateFilterContainer>
 			<DateButton>

--- a/src/pages/reservation/Reservation.tsx
+++ b/src/pages/reservation/Reservation.tsx
@@ -13,8 +13,10 @@ import { useFlights } from '@/hooks/useFlights';
 import styled from 'styled-components';
 
 const Reservation = () => {
-	const startdDate = '2024-11-6';
-	const finishDate = '2024-11-13';
+	const searchParams = new URLSearchParams(window.location.search);
+	const startDate = searchParams.get('startDate');
+	const finishDate = searchParams.get('finishDate');
+
 	const { flights } = useFlights();
 
 	return (
@@ -22,7 +24,7 @@ const Reservation = () => {
 			<TopBar>
 				<LocationInput />
 				<FilterContainer>
-					<DateFilter startDate={startdDate} finishDate={finishDate} />
+					<DateFilter startDate={startDate} finishDate={finishDate} />
 					<Filter people={1} content="성인" />
 					<Filter content="일반석" />
 				</FilterContainer>


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #63 

## ✅ 작업 리스트

- [x] 날짜 연동

## 🔧 작업 내용
- search.tsx에서 

```ts
	const searchParams = new URLSearchParams(window.location.search);
	const startDate = searchParams.get('startDate');
	const finishDate = searchParams.get('finishDate');

	const handleSearchClick = () => {
		navigate(`/reservation?startDate=${startDate}&finishDate=${finishDate}`);
	};
```

캘린더에서 날짜를 선택하고 적용을 클릭하면 주소에 그 값이 뜨기 때문에 그걸 해당 페이지에서 다시 가져와 reservation으로 이동할때 위와 같은 경로로 이동하게 했습니다.

```ts
	const searchParams = new URLSearchParams(window.location.search);
	const startDate = searchParams.get('startDate');
	const finishDate = searchParams.get('finishDate');
```

Reservation.tsx에서 다시 URL에서 해당 값을 가져와 할당하고 이 페이지의 컴포넌트에는 home에서 선택한 날짜가 반영됩니다.

## 🧐 새로 알게된 점

## 🤔 궁금한 점
없습니다~~

## 📸 스크린샷 / GIF / Link
![image](https://github.com/user-attachments/assets/2ce7f121-7290-4b83-93ec-6dd0a885015a)

해당 화면에서 이렇게 선택하고 검색하기를 누르면

![image](https://github.com/user-attachments/assets/41f47076-dfc4-48d4-9fd6-e16e6071fe22)


잘 반영됩니다!
